### PR TITLE
Feature/gulp browserify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,14 +95,16 @@ gulp.task('concat', ['clean'], function () {
 
 });
 
-gulp.task( 'browserify', [ 'clean' ], function(){
-    var b = browserify('./js/siteorigin-panels/main.js')
+gulp.task( 'browserify', [ ], function(){
+    if( typeof config.browserify === undefined ) return;
+
+    var b = browserify( config.browserify.src )
         .bundle()
         .on('error', function(e){
             gutil.log( e );
         })
-        .pipe(source('siteorigin-panels.js'))
-        .pipe(gulp.dest('./js/'));
+        .pipe(source(config.browserify.fileName))
+        .pipe(gulp.dest(config.browserify.dest));
 
 } );
 
@@ -133,10 +135,15 @@ gulp.task('build:release', ['move'], function () {
         .pipe(gulp.dest(outDir));
 });
 
-gulp.task('build:dev', ['css'], function () {
+gulp.task('build:dev', [ 'css', 'browserify' ], function () {
     console.log('Watching CSS files...');
     var cssSrc = config.less.src.concat(config.sass.src);
     gulp.watch(cssSrc, ['css']);
+
+    if( typeof config.browserify !== 'undefined' ) {
+        console.log('Watching Browserify files...');
+        gulp.watch(config.browserify.watchFiles, ['browserify']);
+    }
 });
 
 gulp.task('default', ['build:release'], function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,11 @@ var config = require('../build-config.js'),
     zip = require('gulp-zip'),
     path = require('path');
 
+var gutil = require('gulp-util');
+var source = require('vinyl-source-stream');
+var browserify = require('browserify');
+
+
 var args = {};
 if(process.argv.length > 2) {
     var arr = process.argv.slice(2);
@@ -90,7 +95,18 @@ gulp.task('concat', ['clean'], function () {
 
 });
 
-gulp.task('minify', ['concat'], function () {
+gulp.task( 'browserify', [ 'clean' ], function(){
+    var b = browserify('./js/siteorigin-panels/main.js')
+        .bundle()
+        .on('error', function(e){
+            gutil.log( e );
+        })
+        .pipe(source('siteorigin-panels.js'))
+        .pipe(gulp.dest('./js/'));
+
+} );
+
+gulp.task('minify', ['concat', 'browserify'], function () {
     return gulp.src(config.js.src, {base: '.'})
         // This will output the non-minified version
         .pipe(gulp.dest('tmp'))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "siteorigin-panels",
   "version": "2.1.2",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
     "del": "^1.2.0",
     "gulp": "^3.9.0",
@@ -13,6 +14,9 @@
     "gulp-sort": "^1.1.1",
     "gulp-uglify": "^1.2.0",
     "gulp-wp-pot": "^1.0.4",
-    "gulp-zip": "^3.0.2"
+    "gulp-zip": "^3.0.2",
+    "browserify": "^13.0.0",
+    "gulp-util": "^3.0.7",
+    "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
This adds configurable Browserify support. This is what the config looks like: https://github.com/siteorigin/siteorigin-panels/blob/feature/gulp-browserify/build-config.js#L35-L42

A few improvements we could make (like supporting an array of Browserify configs), but this should do for now.

Please feel free to let me know if there's anything that needs to change. New to this.