### PR TITLE
build:release: Add browserify generated files to tmp directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ gulp.task( 'browserify', [ 'babel' ], function () {
 			gutil.log( e );
 		} )
 		.pipe( source( browserifyConfig.fileName ) )
-		.pipe( gulp.dest( browserifyConfig.dest ) );
+		.pipe( gulp.dest( args.target === 'build:release' ? 'tmp/' + browserifyConfig.dest : browserifyConfig.dest ) );
 	};
 
 	if ( Array.isArray( config.browserify ) ) {


### PR DESCRIPTION
Resolve https://github.com/siteorigin/plugin-build/issues/18

On Windows after the build has completed the following error will output:

```
(node:11484) UnhandledPromiseRejectionWarning: Error: EPERM: operation not permitted, unlink 'C:\Users\Alex\Documents\GitHub\siteorigin-panels\tmp\js\siteorigin-panels.js'
(node:11484) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:11484) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This error means that the tmp directory wasn't able to be removed. No issues occur with the build itself. We have two options:

1. Ignore the error as it only affects window devices, and it doesn't affect the build.
2. Work out how to avoid it, and fix it.