### PR TITLE
Don't reminify JS files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,7 +155,13 @@ gulp.task( 'minifyJs', [ 'browserify' ], function () {
 		return;
 	}
 
-	return gulp.src( config.js.src, { base: '.' } )
+	return gulp.src(
+		config.js.src,
+		{
+			base: '.',
+			ignore: '!(*.min)',
+		}
+	)
 	.pipe( gulp.dest( 'tmp' ) )
 	.pipe( rename( { suffix: jsMinSuffix } ) )
 	.pipe( uglify() )


### PR DESCRIPTION
This prevents *.min.min files that was resulting in weird minify issues in the Block Editor.